### PR TITLE
itinerary keyword 통합 테스트 구현

### DIFF
--- a/src/main/java/com/fc/toy_project3/domain/itinerary/service/ItineraryService.java
+++ b/src/main/java/com/fc/toy_project3/domain/itinerary/service/ItineraryService.java
@@ -68,7 +68,7 @@ public class ItineraryService {
      * Kakao Open API [키워드 검색하기] 를 위한 httpEntity를 생성하는 메서드
      */
     @PostConstruct
-    protected void init() {
+    public void init() {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.set(HttpHeaders.AUTHORIZATION, "KakaoAK " + key);

--- a/src/test/java/com/fc/toy_project3/domain/itinerary/unit/service/ItineraryKeywordServiceTest.java
+++ b/src/test/java/com/fc/toy_project3/domain/itinerary/unit/service/ItineraryKeywordServiceTest.java
@@ -1,0 +1,37 @@
+package com.fc.toy_project3.domain.itinerary.unit.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fc.toy_project3.domain.itinerary.dto.response.ItinerarySearchResponseDTO;
+import com.fc.toy_project3.domain.itinerary.service.ItineraryService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class ItineraryKeywordServiceTest {
+
+    @Autowired
+    private ItineraryService itineraryService;
+
+    @Nested
+    @DisplayName("getPlaceByKeyword()는")
+    class Context_getPlaceByKeyword {
+
+        @Test
+        @DisplayName("키워드로 query를 톻해 장소를 조회할 수 있다.")
+        void _willSuccess() throws Exception {
+            // given
+            itineraryService.init();
+
+            // when
+            List<ItinerarySearchResponseDTO> result = itineraryService.getPlaceByKeyword("카카오프렌즈");
+
+            // then
+            assertThat(result.get(0)).isNotNull();
+        }
+    }
+}


### PR DESCRIPTION
- itienrary keyword search에 대한 통합 테스트 구현
- itineraryServiceTest가 아닌 itineraryKeywordServiceTest로 구현
- 이유 : unit Test로 진행시, key와 uri가 직접 노출될 수 있으므로 통합 테스트로 진행했습니다.