### PR TITLE
좋아요 관련 Controller Test 보완 및 Security 적용

### DIFF
--- a/src/main/java/com/fc/toy_project3/domain/like/controller/LikeRestController.java
+++ b/src/main/java/com/fc/toy_project3/domain/like/controller/LikeRestController.java
@@ -4,10 +4,12 @@ import com.fc.toy_project3.domain.like.dto.request.LikeRequestDTO;
 import com.fc.toy_project3.domain.like.dto.response.LikeResponseDTO;
 import com.fc.toy_project3.domain.like.service.LikeService;
 import com.fc.toy_project3.global.common.ResponseDTO;
+import com.fc.toy_project3.global.config.jwt.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,21 +29,29 @@ public class LikeRestController {
     private final LikeService likeService;
 
     @PostMapping
-    public ResponseEntity<ResponseDTO<LikeResponseDTO>> createLike(@Valid @RequestBody LikeRequestDTO likeRequestDTO) {
+    public ResponseEntity<ResponseDTO<LikeResponseDTO>> createLike(
+        @AuthenticationPrincipal CustomUserDetails customUserDetails,
+        @Valid @RequestBody LikeRequestDTO likeRequestDTO) {
         return ResponseEntity.status(HttpStatus.CREATED).body(
-            ResponseDTO.res(HttpStatus.CREATED, likeService.createLike(1L, likeRequestDTO),
+            ResponseDTO.res(HttpStatus.CREATED, likeService.createLike(customUserDetails.getMemberId(), likeRequestDTO),
                 "성공적으로 좋아요 정보를 등록했습니다."));
     }
 
     @GetMapping("/{tripId}")
-    public ResponseEntity<ResponseDTO<LikeResponseDTO>> getLikeByMemberIdAndTripId(@PathVariable Long tripId){
+    public ResponseEntity<ResponseDTO<LikeResponseDTO>> getLikeByMemberIdAndTripId(
+        @AuthenticationPrincipal CustomUserDetails customUserDetails,
+        @PathVariable Long tripId) {
         return ResponseEntity.status(HttpStatus.OK).body(
-            ResponseDTO.res(HttpStatus.OK, likeService.getLikeByMemberIdAndTripId(1L, tripId), "성공적으로 좋아요 정보를 조회했습니다."));
+            ResponseDTO.res(HttpStatus.OK, likeService.getLikeByMemberIdAndTripId(customUserDetails.getMemberId(), tripId),
+                "성공적으로 좋아요 정보를 조회했습니다."));
     }
 
     @DeleteMapping("/{likeId}")
-    public ResponseEntity<ResponseDTO<LikeResponseDTO>> deleteLikeById(@PathVariable Long likeId){
+    public ResponseEntity<ResponseDTO<LikeResponseDTO>> deleteLikeById(
+        @AuthenticationPrincipal CustomUserDetails customUserDetails,
+        @PathVariable Long likeId){
         return ResponseEntity.status(HttpStatus.OK).body(
-            ResponseDTO.res(HttpStatus.OK, likeService.deleteLikeById(1L, likeId), "성공적으로 좋아요 정보를 삭제했습니다."));
+            ResponseDTO.res(HttpStatus.OK, likeService.deleteLikeById(customUserDetails.getMemberId(), likeId),
+                "성공적으로 좋아요 정보를 삭제했습니다."));
     }
 }

--- a/src/main/java/com/fc/toy_project3/domain/like/service/LikeService.java
+++ b/src/main/java/com/fc/toy_project3/domain/like/service/LikeService.java
@@ -6,7 +6,7 @@ import com.fc.toy_project3.domain.like.entity.Like;
 import com.fc.toy_project3.domain.like.exception.LikeNotFoundException;
 import com.fc.toy_project3.domain.like.exception.LikeUnauthorizedException;
 import com.fc.toy_project3.domain.like.repository.LikeRepository;
-import com.fc.toy_project3.domain.member.repository.MemberRepository;
+import com.fc.toy_project3.domain.member.service.MemberService;
 import com.fc.toy_project3.domain.trip.service.TripService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,7 +22,7 @@ public class LikeService {
 
     private final TripService tripService;
     private final LikeRepository likeRepository;
-    private final MemberRepository memberRepository;
+    private final MemberService memberService;
 
     /**
      * 좋아요 정보 등록
@@ -32,11 +32,8 @@ public class LikeService {
      * @return 등록한 좋아요 정보 응답 DTO
      */
     public LikeResponseDTO createLike(Long memberId, LikeRequestDTO likeRequestDTO) {
-        //getMember(), MemberNotFoundException 으로 변경 예정
         Long tripId = likeRequestDTO.getTripId();
-        Like like = Like.builder().member(memberRepository.findById(memberId).orElseThrow(LikeNotFoundException::new))
-            .trip(tripService.getTrip(tripId))
-            .build();
+        Like like = Like.builder().member(memberService.getMember(memberId)).trip(tripService.getTrip(tripId)).build();
         tripService.like(tripId, true);
         return new LikeResponseDTO(likeRepository.save(like));
     }

--- a/src/test/java/com/fc/toy_project3/docs/RestDocsSupport.java
+++ b/src/test/java/com/fc/toy_project3/docs/RestDocsSupport.java
@@ -2,6 +2,7 @@ package com.fc.toy_project3.docs;
 
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -18,6 +19,7 @@ import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 @Disabled
@@ -32,12 +34,16 @@ public abstract class RestDocsSupport {
     @Autowired
     protected RestDocumentationResultHandler restDoc;
 
+    @Autowired
+    WebApplicationContext context;
+
     protected MockMvc mockMvc;
 
     @BeforeEach
     public void setup(RestDocumentationContextProvider restDocumentationContextProvider) {
-        this.mockMvc = MockMvcBuilders.standaloneSetup(initController())
-            .apply(documentationConfiguration(restDocumentationContextProvider)).alwaysDo(print())
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+            .apply(documentationConfiguration(restDocumentationContextProvider))
+            .apply(springSecurity()).alwaysDo(print())
             .alwaysDo(restDoc).addFilters(new CharacterEncodingFilter("UTF-8", true)).build();
     }
 

--- a/src/test/java/com/fc/toy_project3/domain/like/docs/LikeRestControllerDocsTest.java
+++ b/src/test/java/com/fc/toy_project3/domain/like/docs/LikeRestControllerDocsTest.java
@@ -98,7 +98,7 @@ public class LikeRestControllerDocsTest extends RestDocsSupport {
     @Test
     @DisplayName("deleteLikeById()은 특정 id를 가진 좋아요 정보를 삭제할 수 있다.")
     void deleteLikeById() throws Exception {
-        //given
+        // given
         Long likeId = 1L; Long memberId = 1L;
         LikeResponseDTO likeResponseDTO = LikeResponseDTO.builder().likeId(likeId).memberId(1L).tripId(1L).build();
 
@@ -107,7 +107,7 @@ public class LikeRestControllerDocsTest extends RestDocsSupport {
         CustomUserDetails customUserDetails = new CustomUserDetails(1L, "test", "test@mail.com",
             "test");
 
-        //when, then
+        // when, then
         mockMvc.perform(RestDocumentationRequestBuilders.delete("/api/likes/{likeId}", 1L)
                 .with(user(customUserDetails))
                 .with(csrf()))

--- a/src/test/java/com/fc/toy_project3/domain/like/unit/contoller/LikeRestControllerTest.java
+++ b/src/test/java/com/fc/toy_project3/domain/like/unit/contoller/LikeRestControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -51,7 +52,7 @@ public class LikeRestControllerTest {
             given(likeService.createLike(memberId, likeRequestDTO)).willReturn(likeResponseDTO);
 
             //when, then
-            mockMvc.perform(post("/api/likes")
+            mockMvc.perform(post("/api/likes").with(csrf())
                 .content(new ObjectMapper().writeValueAsString(likeRequestDTO))
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isCreated())
@@ -75,7 +76,7 @@ public class LikeRestControllerTest {
                 LikeRequestDTO likeRequestDTO = LikeRequestDTO.builder().tripId(null).build();
 
                 // when, then
-                mockMvc.perform(post("/api/trip")
+                mockMvc.perform(post("/api/trip").with(csrf())
                         .content(new ObjectMapper().writeValueAsString(likeRequestDTO))
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
                     .andDo(print());
@@ -100,7 +101,7 @@ public class LikeRestControllerTest {
             given(likeService.getLikeByMemberIdAndTripId(memberId, tripId)).willReturn(likeResponseDTO);
 
             //when, then
-            mockMvc.perform(get("/api/likes/{tripId}", 1L))
+            mockMvc.perform(get("/api/likes/{tripId}", 1L).with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
                 .andExpect(jsonPath("$.data").isMap())
@@ -128,7 +129,7 @@ public class LikeRestControllerTest {
             given(likeService.deleteLikeById(memberId, tripId)).willReturn(likeResponseDTO);
 
             //when, then
-            mockMvc.perform(delete("/api/likes/{likeId}", 1L))
+            mockMvc.perform(delete("/api/likes/{likeId}", 1L).with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
                 .andExpect(jsonPath("$.data").isMap())

--- a/src/test/java/com/fc/toy_project3/domain/like/unit/contoller/LikeRestControllerTest.java
+++ b/src/test/java/com/fc/toy_project3/domain/like/unit/contoller/LikeRestControllerTest.java
@@ -26,7 +26,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(LikeRestController.class)
@@ -38,13 +37,17 @@ public class LikeRestControllerTest {
     @MockBean
     private LikeService likeService;
 
+    private CustomUserDetails makeUserInfo(){
+        return new CustomUserDetails(1L, "test", "test@mail.com","test");
+    }
+
+    ObjectMapper objectMapper = new ObjectMapper();
     @Nested
     @DisplayName("createLike()는")
     class Context_createLike {
 
         @Test
         @DisplayName("좋아요 정보를 등록할 수 있다.")
-        @WithMockUser
         void _willSuccess() throws Exception {
             //given
             Long memberId = 1L;
@@ -55,11 +58,9 @@ public class LikeRestControllerTest {
 
             given(likeService.createLike(any(Long.TYPE), any(LikeRequestDTO.class))).willReturn(likeResponseDTO);
 
-            CustomUserDetails customUserDetails = new CustomUserDetails(1L, "test", "test@mail.com","test");
-
             //when, then
-            mockMvc.perform(post("/api/likes").with(user(customUserDetails)).with(csrf())
-                .content(new ObjectMapper().writeValueAsString(likeRequestDTO))
+            mockMvc.perform(post("/api/likes").with(user(makeUserInfo())).with(csrf())
+                .content(objectMapper.writeValueAsString(likeRequestDTO))
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
@@ -80,11 +81,11 @@ public class LikeRestControllerTest {
                 // given
                 LikeRequestDTO likeRequestDTO = LikeRequestDTO.builder().tripId(null).build();
 
-                CustomUserDetails customUserDetails = new CustomUserDetails(1L, "test", "test@mail.com","test");
+                CustomUserDetails customUserDetails = makeUserInfo();
 
                 // when, then
                 mockMvc.perform(post("/api/likes").with(user(customUserDetails)).with(csrf())
-                        .content(new ObjectMapper().writeValueAsString(likeRequestDTO))
+                        .content(objectMapper.writeValueAsString(likeRequestDTO))
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
                     .andDo(print());
                 verify(likeService, never()).createLike(any(Long.TYPE), any(LikeRequestDTO.class));
@@ -107,10 +108,8 @@ public class LikeRestControllerTest {
 
             given(likeService.getLikeByMemberIdAndTripId(memberId, tripId)).willReturn(likeResponseDTO);
 
-            CustomUserDetails customUserDetails = new CustomUserDetails(1L, "test", "test@mail.com","test");
-
             //when, then
-            mockMvc.perform(get("/api/likes/{tripId}", 1L).with(user(customUserDetails)).with(csrf()))
+            mockMvc.perform(get("/api/likes/{tripId}", 1L).with(user(makeUserInfo())).with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
                 .andExpect(jsonPath("$.data.likeId").exists())
@@ -136,10 +135,8 @@ public class LikeRestControllerTest {
 
             given(likeService.deleteLikeById(memberId, tripId)).willReturn(likeResponseDTO);
 
-            CustomUserDetails customUserDetails = new CustomUserDetails(1L, "test", "test@mail.com","test");
-
             //when, then
-            mockMvc.perform(delete("/api/likes/{likeId}", 1L).with(user(customUserDetails)).with(csrf()))
+            mockMvc.perform(delete("/api/likes/{likeId}", 1L).with(user(makeUserInfo())).with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
                 .andExpect(jsonPath("$.data.likeId").exists())

--- a/src/test/java/com/fc/toy_project3/domain/like/unit/contoller/LikeRestControllerTest.java
+++ b/src/test/java/com/fc/toy_project3/domain/like/unit/contoller/LikeRestControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -17,6 +18,7 @@ import com.fc.toy_project3.domain.like.controller.LikeRestController;
 import com.fc.toy_project3.domain.like.dto.request.LikeRequestDTO;
 import com.fc.toy_project3.domain.like.dto.response.LikeResponseDTO;
 import com.fc.toy_project3.domain.like.service.LikeService;
+import com.fc.toy_project3.global.config.jwt.CustomUserDetails;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -24,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(LikeRestController.class)
@@ -41,6 +44,7 @@ public class LikeRestControllerTest {
 
         @Test
         @DisplayName("좋아요 정보를 등록할 수 있다.")
+        @WithMockUser
         void _willSuccess() throws Exception {
             //given
             Long memberId = 1L;
@@ -51,8 +55,10 @@ public class LikeRestControllerTest {
 
             given(likeService.createLike(memberId, likeRequestDTO)).willReturn(likeResponseDTO);
 
+            CustomUserDetails customUserDetails = new CustomUserDetails(1L, "test", "test@mail.com","test");
+
             //when, then
-            mockMvc.perform(post("/api/likes").with(csrf())
+            mockMvc.perform(post("/api/likes").with(user(customUserDetails)).with(csrf())
                 .content(new ObjectMapper().writeValueAsString(likeRequestDTO))
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isCreated())
@@ -75,8 +81,10 @@ public class LikeRestControllerTest {
                 // given
                 LikeRequestDTO likeRequestDTO = LikeRequestDTO.builder().tripId(null).build();
 
+                CustomUserDetails customUserDetails = new CustomUserDetails(1L, "test", "test@mail.com","test");
+
                 // when, then
-                mockMvc.perform(post("/api/trip").with(csrf())
+                mockMvc.perform(post("/api/trip").with(user(customUserDetails)).with(csrf())
                         .content(new ObjectMapper().writeValueAsString(likeRequestDTO))
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
                     .andDo(print());
@@ -100,8 +108,10 @@ public class LikeRestControllerTest {
 
             given(likeService.getLikeByMemberIdAndTripId(memberId, tripId)).willReturn(likeResponseDTO);
 
+            CustomUserDetails customUserDetails = new CustomUserDetails(1L, "test", "test@mail.com","test");
+
             //when, then
-            mockMvc.perform(get("/api/likes/{tripId}", 1L).with(csrf()))
+            mockMvc.perform(get("/api/likes/{tripId}", 1L).with(user(customUserDetails)).with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
                 .andExpect(jsonPath("$.data").isMap())
@@ -128,8 +138,10 @@ public class LikeRestControllerTest {
 
             given(likeService.deleteLikeById(memberId, tripId)).willReturn(likeResponseDTO);
 
+            CustomUserDetails customUserDetails = new CustomUserDetails(1L, "test", "test@mail.com","test");
+
             //when, then
-            mockMvc.perform(delete("/api/likes/{likeId}", 1L).with(csrf()))
+            mockMvc.perform(delete("/api/likes/{likeId}", 1L).with(user(customUserDetails)).with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
                 .andExpect(jsonPath("$.data").isMap())

--- a/src/test/java/com/fc/toy_project3/domain/like/unit/contoller/LikeRestControllerTest.java
+++ b/src/test/java/com/fc/toy_project3/domain/like/unit/contoller/LikeRestControllerTest.java
@@ -1,38 +1,38 @@
 package com.fc.toy_project3.domain.like.unit.contoller;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fc.toy_project3.domain.like.controller.LikeRestController;
 import com.fc.toy_project3.domain.like.dto.request.LikeRequestDTO;
 import com.fc.toy_project3.domain.like.dto.response.LikeResponseDTO;
 import com.fc.toy_project3.domain.like.service.LikeService;
-import com.fc.toy_project3.global.common.ResponseDTO;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
 
+@WebMvcTest(LikeRestController.class)
 public class LikeRestControllerTest {
 
-    @InjectMocks
-    private LikeRestController likeRestController;
+    @Autowired
+    private MockMvc mockMvc;
 
-    @Mock
+    @MockBean
     private LikeService likeService;
-
-    @BeforeEach
-    void setup() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("createLike()는")
@@ -40,7 +40,7 @@ public class LikeRestControllerTest {
 
         @Test
         @DisplayName("좋아요 정보를 등록할 수 있다.")
-        void _willSuccess() {
+        void _willSuccess() throws Exception {
             //given
             Long memberId = 1L;
             Long tripId = 1L;
@@ -50,15 +50,37 @@ public class LikeRestControllerTest {
 
             given(likeService.createLike(memberId, likeRequestDTO)).willReturn(likeResponseDTO);
 
-            //when
-            ResponseEntity<ResponseDTO<LikeResponseDTO>> responseEntity = likeRestController.createLike(likeRequestDTO);
+            //when, then
+            mockMvc.perform(post("/api/likes")
+                .content(new ObjectMapper().writeValueAsString(likeRequestDTO))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
+                .andExpect(jsonPath("$.data").isMap())
+                .andExpect(jsonPath("$.data.likeId").exists())
+                .andExpect(jsonPath("$.data.memberId").exists())
+                .andExpect(jsonPath("$.data.tripId").exists())
+                .andDo(print());
+            verify(likeService, times(1)).createLike(any(Long.TYPE), any(LikeRequestDTO.class));
+        }
 
-            //then
-            assertEquals(HttpStatus.CREATED, responseEntity.getStatusCode());
-            assertNotNull(responseEntity.getBody().getData());
-            assertEquals(memberId, responseEntity.getBody().getData().getMemberId());
-            assertEquals(likeRequestDTO.getTripId(), responseEntity.getBody().getData().getTripId());
-            verify(likeService, times(1)).createLike(memberId, likeRequestDTO);
+        @Nested
+        @DisplayName("tripId가 ")
+        class Element_tripId {
+
+            @Test
+            @DisplayName("null일 경우 좋아요 정보를 저장할 수 없다.")
+            void null_willFail() throws Exception {
+                // given
+                LikeRequestDTO likeRequestDTO = LikeRequestDTO.builder().tripId(null).build();
+
+                // when, then
+                mockMvc.perform(post("/api/trip")
+                        .content(new ObjectMapper().writeValueAsString(likeRequestDTO))
+                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
+                    .andDo(print());
+                verify(likeService, never()).createLike(any(Long.TYPE), any(LikeRequestDTO.class));
+            }
         }
     }
 
@@ -68,7 +90,7 @@ public class LikeRestControllerTest {
 
         @Test
         @DisplayName("특정 회원 id와 여행 id를 가진 좋아요 정보를 조회할 수 있다.")
-        void _willSuccess() {
+        void _willSuccess() throws Exception {
             //given
             Long memberId = 1L;
             Long tripId = 1L;
@@ -77,14 +99,15 @@ public class LikeRestControllerTest {
 
             given(likeService.getLikeByMemberIdAndTripId(memberId, tripId)).willReturn(likeResponseDTO);
 
-            //when
-            ResponseEntity<ResponseDTO<LikeResponseDTO>> responseEntity = likeRestController.getLikeByMemberIdAndTripId(tripId);
-
-            //then
-            assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
-            assertNotNull(responseEntity.getBody().getData());
-            assertEquals(memberId, responseEntity.getBody().getData().getMemberId());
-            assertEquals(tripId, responseEntity.getBody().getData().getTripId());
+            //when, then
+            mockMvc.perform(get("/api/likes/{tripId}", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
+                .andExpect(jsonPath("$.data").isMap())
+                .andExpect(jsonPath("$.data.likeId").exists())
+                .andExpect(jsonPath("$.data.memberId").exists())
+                .andExpect(jsonPath("$.data.tripId").exists())
+                .andDo(print());
             verify(likeService, times(1)).getLikeByMemberIdAndTripId(any(Long.TYPE), any(Long.TYPE));
         }
     }
@@ -95,7 +118,7 @@ public class LikeRestControllerTest {
 
         @Test
         @DisplayName("특정 id를 가진 좋아요 정보를 삭제할 수 있다.")
-        void _willSuccess() {
+        void _willSuccess() throws Exception {
             //given
             Long likeId = 1L;
             Long memberId = 1L;
@@ -104,14 +127,15 @@ public class LikeRestControllerTest {
 
             given(likeService.deleteLikeById(memberId, tripId)).willReturn(likeResponseDTO);
 
-            //when
-            ResponseEntity<ResponseDTO<LikeResponseDTO>> responseEntity = likeRestController.deleteLikeById(likeId);
-
-            //then
-            assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
-            assertNotNull(responseEntity.getBody().getData());
-            assertEquals(likeId, responseEntity.getBody().getData().getLikeId());
-            assertEquals(memberId, responseEntity.getBody().getData().getMemberId());
+            //when, then
+            mockMvc.perform(delete("/api/likes/{likeId}", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
+                .andExpect(jsonPath("$.data").isMap())
+                .andExpect(jsonPath("$.data.likeId").exists())
+                .andExpect(jsonPath("$.data.memberId").exists())
+                .andExpect(jsonPath("$.data.tripId").exists())
+                .andDo(print());
             verify(likeService, times(1)).deleteLikeById(any(Long.TYPE), any(Long.TYPE));
         }
     }

--- a/src/test/java/com/fc/toy_project3/domain/like/unit/contoller/LikeRestControllerTest.java
+++ b/src/test/java/com/fc/toy_project3/domain/like/unit/contoller/LikeRestControllerTest.java
@@ -49,7 +49,7 @@ public class LikeRestControllerTest {
         @Test
         @DisplayName("좋아요 정보를 등록할 수 있다.")
         void _willSuccess() throws Exception {
-            //given
+            // given
             Long memberId = 1L;
             Long tripId = 1L;
             Long likeId = 1L;
@@ -58,7 +58,7 @@ public class LikeRestControllerTest {
 
             given(likeService.createLike(any(Long.TYPE), any(LikeRequestDTO.class))).willReturn(likeResponseDTO);
 
-            //when, then
+            // when, then
             mockMvc.perform(post("/api/likes").with(user(makeUserInfo())).with(csrf())
                 .content(objectMapper.writeValueAsString(likeRequestDTO))
                 .contentType(MediaType.APPLICATION_JSON))
@@ -100,7 +100,7 @@ public class LikeRestControllerTest {
         @Test
         @DisplayName("특정 회원 id와 여행 id를 가진 좋아요 정보를 조회할 수 있다.")
         void _willSuccess() throws Exception {
-            //given
+            // given
             Long memberId = 1L;
             Long tripId = 1L;
             Long likeId = 1L;
@@ -108,7 +108,7 @@ public class LikeRestControllerTest {
 
             given(likeService.getLikeByMemberIdAndTripId(memberId, tripId)).willReturn(likeResponseDTO);
 
-            //when, then
+            // when, then
             mockMvc.perform(get("/api/likes/{tripId}", 1L).with(user(makeUserInfo())).with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
@@ -127,7 +127,7 @@ public class LikeRestControllerTest {
         @Test
         @DisplayName("특정 id를 가진 좋아요 정보를 삭제할 수 있다.")
         void _willSuccess() throws Exception {
-            //given
+            // given
             Long likeId = 1L;
             Long memberId = 1L;
             Long tripId = 1L;
@@ -135,7 +135,7 @@ public class LikeRestControllerTest {
 
             given(likeService.deleteLikeById(memberId, tripId)).willReturn(likeResponseDTO);
 
-            //when, then
+            // when, then
             mockMvc.perform(delete("/api/likes/{likeId}", 1L).with(user(makeUserInfo())).with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())

--- a/src/test/java/com/fc/toy_project3/domain/like/unit/contoller/LikeRestControllerTest.java
+++ b/src/test/java/com/fc/toy_project3/domain/like/unit/contoller/LikeRestControllerTest.java
@@ -53,7 +53,7 @@ public class LikeRestControllerTest {
             LikeRequestDTO likeRequestDTO = LikeRequestDTO.builder().tripId(tripId).build();
             LikeResponseDTO likeResponseDTO = LikeResponseDTO.builder().likeId(likeId).memberId(memberId).tripId(tripId).build();
 
-            given(likeService.createLike(memberId, likeRequestDTO)).willReturn(likeResponseDTO);
+            given(likeService.createLike(any(Long.TYPE), any(LikeRequestDTO.class))).willReturn(likeResponseDTO);
 
             CustomUserDetails customUserDetails = new CustomUserDetails(1L, "test", "test@mail.com","test");
 
@@ -63,7 +63,6 @@ public class LikeRestControllerTest {
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
-                .andExpect(jsonPath("$.data").isMap())
                 .andExpect(jsonPath("$.data.likeId").exists())
                 .andExpect(jsonPath("$.data.memberId").exists())
                 .andExpect(jsonPath("$.data.tripId").exists())
@@ -84,7 +83,7 @@ public class LikeRestControllerTest {
                 CustomUserDetails customUserDetails = new CustomUserDetails(1L, "test", "test@mail.com","test");
 
                 // when, then
-                mockMvc.perform(post("/api/trip").with(user(customUserDetails)).with(csrf())
+                mockMvc.perform(post("/api/likes").with(user(customUserDetails)).with(csrf())
                         .content(new ObjectMapper().writeValueAsString(likeRequestDTO))
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
                     .andDo(print());
@@ -114,7 +113,6 @@ public class LikeRestControllerTest {
             mockMvc.perform(get("/api/likes/{tripId}", 1L).with(user(customUserDetails)).with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
-                .andExpect(jsonPath("$.data").isMap())
                 .andExpect(jsonPath("$.data.likeId").exists())
                 .andExpect(jsonPath("$.data.memberId").exists())
                 .andExpect(jsonPath("$.data.tripId").exists())
@@ -144,7 +142,6 @@ public class LikeRestControllerTest {
             mockMvc.perform(delete("/api/likes/{likeId}", 1L).with(user(customUserDetails)).with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
-                .andExpect(jsonPath("$.data").isMap())
                 .andExpect(jsonPath("$.data.likeId").exists())
                 .andExpect(jsonPath("$.data.memberId").exists())
                 .andExpect(jsonPath("$.data.tripId").exists())

--- a/src/test/java/com/fc/toy_project3/domain/like/unit/repository/LikeRepositoryTest.java
+++ b/src/test/java/com/fc/toy_project3/domain/like/unit/repository/LikeRepositoryTest.java
@@ -75,7 +75,7 @@ public class LikeRepositoryTest {
         @Test
         @DisplayName("좋아요 정보를 저장할 수 있다.")
         void _willSuccess() {
-            //given
+            // given
             Long memberId = 1L, tripId = 1L;
             Member member = Member.builder().id(memberId).email("fc123@naver.com").nickname("닉1").password("1234").build();
             Trip trip = Trip.builder().id(tripId).name("제주도 여행").startDate(LocalDate.of(2023, 10, 25))
@@ -91,10 +91,10 @@ public class LikeRepositoryTest {
 
             Like like = Like.builder().id(1L).trip(trip).member(member).build();
 
-            //when
+            // when
             Like result = likeRepository.save(like);
 
-            //then
+            // then
             assertEquals(like.getId(), result.getId());
             assertEquals(member.getId(), result.getMember().getId());
             assertEquals(trip.getId(), result.getTrip().getId());
@@ -108,7 +108,7 @@ public class LikeRepositoryTest {
         @Test
         @DisplayName("특정 회원 id와 여행 id를 가진 좋아요 정보 Entity를 조회할 수 있다.")
         void _willSuccess() {
-            //given
+            // given
             Long memberId = 1L, tripId = 1L;
             Member member = Member.builder().id(memberId).email("fc123@naver.com").nickname("닉1").password("1234").build();
             Trip trip = Trip.builder().id(tripId).name("제주도 여행").startDate(LocalDate.of(2023, 10, 25))
@@ -128,7 +128,7 @@ public class LikeRepositoryTest {
             // when
             Optional<Like> result = likeRepository.findByMemberIdAndTripId(memberId, tripId);
 
-            //then
+            // then
             assertNotNull(result.get().getId());
             assertEquals(memberId, result.get().getMember().getId());
             assertEquals(tripId, result.get().getTrip().getId());
@@ -220,7 +220,7 @@ public class LikeRepositoryTest {
         @Test
         @DisplayName("특정 id를 가진 좋아요 정보 Entity를 조회할 수 있다.")
         void _willSuccess() {
-            //given
+            // given
             Long likeId = 1L;
             Member member = Member.builder().id(1L).email("fc123@naver.com").nickname("닉1").password("1234").build();
             Trip trip = Trip.builder().id(1L).name("제주도 여행").startDate(LocalDate.of(2023, 10, 25))
@@ -232,10 +232,10 @@ public class LikeRepositoryTest {
             tripRepository.save(trip);
             Like savedLike = likeRepository.save(like);
 
-            //when
+            // when
             Optional<Like> result = likeRepository.findById(likeId);
 
-            //then
+            // then
             assertNotNull(result);
             assertEquals(savedLike.getId(), result.get().getId());
             assertEquals(savedLike.getMember().getId(), result.get().getId());
@@ -250,7 +250,7 @@ public class LikeRepositoryTest {
         @Test
         @DisplayName("특정 id를 가진 좋아요 정보를 삭제할 수 있다.")
         void _willSuccess() {
-            //given
+            // given
             Member member = Member.builder().id(1L).email("fc123@naver.com").nickname("닉1").password("1234").build();
             Trip trip = Trip.builder().id(1L).name("제주도 여행").startDate(LocalDate.of(2023, 10, 25))
                 .endDate(LocalDate.of(2023, 10, 26)).isDomestic(true).itineraries(new ArrayList<>())
@@ -261,10 +261,10 @@ public class LikeRepositoryTest {
             tripRepository.save(trip);
             Like savedLike = likeRepository.save(like);
 
-            //when
+            // when
             likeRepository.deleteById(1L);
 
-            //then
+            // then
             assertFalse(likeRepository.existsById(savedLike.getId()));
         }
     }

--- a/src/test/java/com/fc/toy_project3/domain/like/unit/service/LikeServiceTest.java
+++ b/src/test/java/com/fc/toy_project3/domain/like/unit/service/LikeServiceTest.java
@@ -15,7 +15,7 @@ import com.fc.toy_project3.domain.like.exception.LikeNotFoundException;
 import com.fc.toy_project3.domain.like.repository.LikeRepository;
 import com.fc.toy_project3.domain.like.service.LikeService;
 import com.fc.toy_project3.domain.member.entity.Member;
-import com.fc.toy_project3.domain.member.repository.MemberRepository;
+import com.fc.toy_project3.domain.member.service.MemberService;
 import com.fc.toy_project3.domain.trip.entity.Trip;
 import com.fc.toy_project3.domain.trip.service.TripService;
 import java.time.LocalDate;
@@ -40,7 +40,7 @@ class LikeServiceTest {
     @Mock
     private LikeRepository likeRepository;
     @Mock
-    private MemberRepository memberRepository;
+    private MemberService memberService;
     @Mock
     private TripService tripService;
 
@@ -62,7 +62,7 @@ class LikeServiceTest {
             Like like = Like.builder().id(1L).trip(trip).member(member).build();
 
             given(likeRepository.save(any(Like.class))).willReturn(like);
-            given(memberRepository.findById(any(Long.TYPE))).willReturn(Optional.ofNullable(member));
+            given(memberService.getMember(any(Long.TYPE))).willReturn(member);
             given(tripService.getTrip(any(Long.TYPE))).willReturn(trip);
 
             // when

--- a/src/test/java/com/fc/toy_project3/domain/like/unit/service/LikeServiceTest.java
+++ b/src/test/java/com/fc/toy_project3/domain/like/unit/service/LikeServiceTest.java
@@ -51,7 +51,7 @@ class LikeServiceTest {
         @Test
         @DisplayName("좋아요 정보를 저장할 수 있다.")
         void _willSuccess() {
-            //given
+            // given
             LikeRequestDTO likeRequestDTO = LikeRequestDTO.builder().tripId(1L).build();
             Long memberId = 1L;
 


### PR DESCRIPTION
[개발목록] 
--
1. LikeService에서 member 정보 가져올 경우, getMember활용하도록 코드 수정
2. LikeRestControllerTest mockmvc 활용하여 재구현 
3. LikeRestControllerTest 실패케이스 추가 
4. 시큐리티 도입하여 컨트롤러 부분 수정

[리팩토링] 
--
1. makeUserInfo(): 테스트코드 내 자주 사용되는 유저정보 생성 코드 함수로 만들어 사용. 
2. 테스트케이스마다 생성되는 ObjectMapper 전역변수로 선언 후 사용
3. 테스트케이스 내 주석 통일 //_given, when, then